### PR TITLE
attempt #2: use Zach's suggestion on Twitter

### DIFF
--- a/03-final/_data/Image.js
+++ b/03-final/_data/Image.js
@@ -1,5 +1,0 @@
-const Image = require("@11ty/eleventy-img");
-
-module.exports = function() {
-  return Image;
-}

--- a/03-final/_includes/webc/img.webc
+++ b/03-final/_includes/webc/img.webc
@@ -1,6 +1,7 @@
 <script webc:type="render" webc:is="template">
-async function() {
-  let metadata = await this.Image(this.src, {
+const Image = require("@11ty/eleventy-img");
+module.exports = async function() {
+  let metadata = await Image(this.src, {
     widths: [300],
     formats: ["avif", "jpeg"],
     outputDir: "_site/img/",
@@ -15,6 +16,6 @@ async function() {
   };
 
   // You bet we throw an error on missing alt in `imageAttributes` (alt="" works okay)
-  return this.Image.generateHTML(metadata, imageAttributes);
+  return Image.generateHTML(metadata, imageAttributes);
 }
 </script>


### PR DESCRIPTION
Unsuccessful attempt.

Reproduction steps:
```bash
git clone git@github.com/RobinCsl/11ty-webc-img-demo.git
git checkout rcsl/attempt-1
cd 03-final
npm i
npx @11ty/eleventy --serve
```

```
npx @11ty/eleventy --serve
[11ty] Problem writing Eleventy templates: (more in DEBUG output)
[11ty] 1. Having trouble rendering webc template ./index.webc (via TemplateContentRenderError)
[11ty] 2. Error parsing WebC scripted render function (./index.webc): Error: Cannot find module '@11ty/eleventy-img'
[11ty] Require stack:
[11ty] - 
[11ty] 
[11ty] const Image = require("@11ty/eleventy-img");
[11ty] module.exports = async function() {
[11ty]   let metadata = await Image(this.src, {
[11ty]     widths: [300],
[11ty]     formats: ["avif", "jpeg"],
[11ty]     outputDir: "_site/img/",
[11ty]   });
[11ty] 
[11ty]   let imageAttributes = {
[11ty]     alt: this.alt,
[11ty]     sizes: '100vw',
[11ty]     loading: "lazy",
[11ty]     decoding: "async",
[11ty]     "webc:raw": true,
[11ty]   };
[11ty] 
[11ty]   // You bet we throw an error on missing alt in `imageAttributes` (alt="" works okay)
[11ty]   return Image.generateHTML(metadata, imageAttributes);
[11ty] } (via Error)
[11ty] 
[11ty] Original error stack trace: Error: Error parsing WebC scripted render function (./index.webc): Error: Cannot find module '@11ty/eleventy-img'
[11ty] Require stack:
[11ty] - 
[11ty] 
[11ty] const Image = require("@11ty/eleventy-img");
[11ty] module.exports = async function() {
[11ty]   let metadata = await Image(this.src, {
[11ty]     widths: [300],
[11ty]     formats: ["avif", "jpeg"],
[11ty]     outputDir: "_site/img/",
[11ty]   });
[11ty] 
[11ty]   let imageAttributes = {
[11ty]     alt: this.alt,
[11ty]     sizes: '100vw',
[11ty]     loading: "lazy",
[11ty]     decoding: "async",
[11ty]     "webc:raw": true,
[11ty]   };
[11ty] 
[11ty]   // You bet we throw an error on missing alt in `imageAttributes` (alt="" works okay)
[11ty]   return Image.generateHTML(metadata, imageAttributes);
[11ty] }
[11ty] 
[11ty]     at Function.getModule (file:///home/robincsl/Repositories/11ty-webc-img-demo/03-final/node_modules/@11ty/webc/src/moduleScript.js:66:10)
[11ty]     at Object.<anonymous> (file:///home/robincsl/Repositories/11ty-webc-img-demo/03-final/node_modules/@11ty/webc/src/ast.js:119:26)
[11ty]     at AstSerializer.transformContent (file:///home/robincsl/Repositories/11ty-webc-img-demo/03-final/node_modules/@11ty/webc/src/ast.js:723:42)
[11ty]     at AstSerializer.compileNode (file:///home/robincsl/Repositories/11ty-webc-img-demo/03-final/node_modules/@11ty/webc/src/ast.js:1061:20)
[11ty]     at AstSerializer.getChildContent (file:///home/robincsl/Repositories/11ty-webc-img-demo/03-final/node_modules/@11ty/webc/src/ast.js:579:40)
[11ty]     at AstSerializer.compileNode (file:///home/robincsl/Repositories/11ty-webc-img-demo/03-final/node_modules/@11ty/webc/src/ast.js:1181:46)
[11ty]     at async AstSerializer.getChildContent (file:///home/robincsl/Repositories/11ty-webc-img-demo/03-final/node_modules/@11ty/webc/src/ast.js:579:29)
[11ty]     at async AstSerializer.compileNode (file:///home/robincsl/Repositories/11ty-webc-img-demo/03-final/node_modules/@11ty/webc/src/ast.js:1218:36)
[11ty]     at async AstSerializer.getChildContent (file:///home/robincsl/Repositories/11ty-webc-img-demo/03-final/node_modules/@11ty/webc/src/ast.js:579:29)
[11ty]     at async AstSerializer.compileNode (file:///home/robincsl/Repositories/11ty-webc-img-demo/03-final/node_modules/@11ty/webc/src/ast.js:1218:36)
[11ty] Wrote 0 files in 0.32 seconds (v2.0.0-canary.16)
```